### PR TITLE
Update `pspike` for Spike API change, and also update the README.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           git clone https://github.com/riscv-software-src/riscv-isa-sim.git
           cd riscv-isa-sim
-          git reset --hard 91793ed7d964aa0031c5a9a31fa05ec3d11b3b0f
+          git reset --hard 3f79e3b7ded80d9ef0e722126b3765207e010711
           mkdir build
           cd build
           ../configure --prefix=${{ github.workspace }}/riscv

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ The Spike simulator is known as the RISC-V gold standard simulator, and although
 3. Golang 1.19+
 4. `riscv-pk` if you need to generate user-mode binaries
 
+## Cloning
+
+This repository uses the `riscv-test-env` repository as a submodule.
+
+```
+git clone --recurse-submodules https://github.com/chipsalliance/riscv-vector-tests
+```
+
 ## How to use
 
 ```

--- a/pspike/pspike.cc
+++ b/pspike/pspike.cc
@@ -89,7 +89,8 @@ int main(int argc, char** argv) {
             true,
             nullptr,
             false,
-            nullptr);
+            nullptr,
+            std::nullopt);
   magic_extension_t magic;
   sim.get_core(0)->register_extension(&magic);
   sim.run();


### PR DESCRIPTION
This adds cloning instructions to the README since submodules are now involved.

Also update to the Spike api change introduced in riscv-software-src/riscv-isa-sim#1828.