### PR TITLE
Fix format for vgmul.vv

### DIFF
--- a/configs/zvkg/vgmul.vv.toml
+++ b/configs/zvkg/vgmul.vv.toml
@@ -1,5 +1,5 @@
 name = "vgmul.vv"
-format = "vd,vs2"
+format = "vd,vs2,vs1"
 
 [tests]
 base = [


### PR DESCRIPTION
Tests for vgmul.vv were not generated due to an incorrect format.