### PR TITLE
Add support for Bfloat16, Zvfbfmin and Zvfbfwma

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
+  workflow_dispatch:
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -37,7 +39,7 @@ jobs:
       - name: Install Toolchain
         if: steps.cache-spike.outputs.cache-hit != 'true'
         run: |
-          wget -O- -q https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2024.04.12/riscv64-elf-ubuntu-22.04-gcc-nightly-2024.04.12-nightly.tar.gz | tar -xzf -
+          wget -O- -q https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2025.07.16/riscv64-elf-ubuntu-22.04-gcc-nightly-2025.07.16-nightly.tar.xz | tar -xJf -
 
       - name: Build Spike
         if: steps.cache-spike.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@
   TEST_MODE = self##
         ##Change to [cosim] if you want to generate faster tests without self-verification (to be used with co-simulators).
         ##
-  MARCH = rv${XLEN}gcv_zvbb_zvbc_zfh_zvfh_zvkg_zvkned_zvknha_zvksed_zvksh
+  MARCH = rv${XLEN}gcv_zvbb_zvbc_zfh_zvfh_zvkg_zvkned_zvknha_zvksed_zvksh_zvfbfmin_zvfbfwma
         ##Set the ISA string to define the base architecture and enabled extensions.
         ##If your compiler doesn't support vector crypto extensions, you can use MARCH = rv${XLEN}gv_zfh_zvfh
         ##If your compiler doesn't support half floating, you can use MARCH = rv${XLEN}gv

--- a/Makefrag
+++ b/Makefrag
@@ -501,6 +501,9 @@ tests = \
   vfncvt_x_f_w-1 \
   vfncvt_xu_f_w-0 \
   vfncvt_xu_f_w-1 \
+  vfncvtbf16_f_f_w-0 \
+  vfncvtbf16_f_f_w-1 \
+  vfncvtbf16_f_f_w-2 \
   vfnmacc_vf-0 \
   vfnmacc_vf-1 \
   vfnmacc_vf-10 \
@@ -805,6 +808,9 @@ tests = \
   vfwcvt_x_f_v-1 \
   vfwcvt_xu_f_v-0 \
   vfwcvt_xu_f_v-1 \
+  vfwcvtbf16_f_f_v-0 \
+  vfwcvtbf16_f_f_v-1 \
+  vfwcvtbf16_f_f_v-2 \
   vfwmacc_vf-0 \
   vfwmacc_vf-1 \
   vfwmacc_vf-2 \
@@ -815,6 +821,19 @@ tests = \
   vfwmacc_vf-7 \
   vfwmacc_vv-0 \
   vfwmacc_vv-1 \
+  vfwmaccbf16_vf-0 \
+  vfwmaccbf16_vf-1 \
+  vfwmaccbf16_vf-2 \
+  vfwmaccbf16_vf-3 \
+  vfwmaccbf16_vf-4 \
+  vfwmaccbf16_vf-5 \
+  vfwmaccbf16_vf-6 \
+  vfwmaccbf16_vf-7 \
+  vfwmaccbf16_vf-8 \
+  vfwmaccbf16_vf-9 \
+  vfwmaccbf16_vv-0 \
+  vfwmaccbf16_vv-1 \
+  vfwmaccbf16_vv-2 \
   vfwmsac_vf-0 \
   vfwmsac_vf-1 \
   vfwmsac_vf-2 \
@@ -857,8 +876,10 @@ tests = \
   vfwnmsac_vv-1 \
   vfwredosum_vs-0 \
   vfwredosum_vs-1 \
+  vfwredosum_vs-2 \
   vfwredusum_vs-0 \
   vfwredusum_vs-1 \
+  vfwredusum_vs-2 \
   vfwsub_vf-0 \
   vfwsub_vf-1 \
   vfwsub_vf-2 \
@@ -1890,6 +1911,7 @@ tests = \
   vsll_vx-5 \
   vsll_vx-6 \
   vsm3c_vi-0 \
+  vsm3c_vi-1 \
   vsm3me_vv-0 \
   vsm4k_vi-0 \
   vsm4k_vi-1 \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository hosts unit tests generator for the RISC-V vector extension.
 - Test SEW from e8 to e64
 - Test LMUL from mf8 to m8
 - Support VLEN from 64 to 4096
-- Support varies sub-extensions: Zvfh, Zvbb, Zvbc, Zvkg, Zvkned, Zvknha, Zvksed and Zvksh
+- Support varies sub-extensions: Zvfh, Zvbb, Zvbc, Zvkg, Zvkned, Zvknha, Zvksed, Zvksh, Zvfbfmin and Zvfbfwma
 - Configurable, see `make help`
 
 ## Limitations

--- a/configs/zvfbfmin/vfncvtbf16.f.f.w.toml
+++ b/configs/zvfbfmin/vfncvtbf16.f.f.w.toml
@@ -1,0 +1,18 @@
+name = "vfncvtbf16.f.f.w"
+format = "vd,vs2,vm"
+
+fsew32 = [
+    ["2.5",                     "1.0"],
+    ["-1235.1",                 "1.1"],
+    ["3.14159265",              "0.00000001"],
+    ["1.1",                     "-1235.1"],
+    ["-1.0",                    "-2.0"],
+    ["nan",                     "-nan"],
+    ["inf",                     "-inf"],
+    ["quiet_nan",               "signaling_nan"],
+    ["smallest_nonzero_float",  "largest_subnormal_float"],
+    ["smallest_normal_float",   "max_float"],
+    ["-smallest_nonzero_float", "-largest_subnormal_float"],
+    ["-smallest_normal_float",  "-max_float"]
+]
+

--- a/configs/zvfbfmin/vfwcvtbf16.f.f.v.toml
+++ b/configs/zvfbfmin/vfwcvtbf16.f.f.v.toml
@@ -1,0 +1,19 @@
+name = "vfwcvtbf16.f.f.v"
+format = "vd,vs2,vm"
+
+[tests]
+bf16sew16 = [
+    ["2.5",                     "1.0"],
+    ["-1235.1",                 "1.1"],
+    ["3.14159265",              "0.00000001"],
+    ["1.1",                     "-1235.1"],
+    ["-1.0",                    "-2.0"],
+    ["nan",                     "-nan"],
+    ["inf",                     "-inf"],
+    ["quiet_nan",               "signaling_nan"],
+    ["smallest_nonzero_float",  "largest_subnormal_float"],
+    ["smallest_normal_float",   "max_float"],
+    ["-smallest_nonzero_float", "-largest_subnormal_float"],
+    ["-smallest_normal_float",  "-max_float"]
+]
+

--- a/configs/zvfbfwma/vfwmaccbf16.vf.toml
+++ b/configs/zvfbfwma/vfwmaccbf16.vf.toml
@@ -1,0 +1,19 @@
+name = "vfwmaccbf16.vf"
+format = "vd,fs1,vs2,vm"
+
+[tests]
+bf16sew16 = [
+    ["2.5",                     "1.0"],
+    ["-1235.1",                 "1.1"],
+    ["3.14159265",              "0.00000001"],
+    ["1.1",                     "-1235.1"],
+    ["-1.0",                    "-2.0"],
+    ["nan",                     "-nan"],
+    ["inf",                     "-inf"],
+    ["quiet_nan",               "signaling_nan"],
+    ["smallest_nonzero_float",  "largest_subnormal_float"],
+    ["smallest_normal_float",   "max_float"],
+    ["-smallest_nonzero_float", "-largest_subnormal_float"],
+    ["-smallest_normal_float",  "-max_float"]
+]
+

--- a/configs/zvfbfwma/vfwmaccbf16.vv.toml
+++ b/configs/zvfbfwma/vfwmaccbf16.vv.toml
@@ -1,0 +1,19 @@
+name = "vfwmaccbf16.vv"
+format = "vd,vs1,vs2,vm"
+
+[tests]
+bf16sew16 = [
+    ["0.0",   "2.5",                     "1.0"],
+    ["-1.0",  "-1235.1",                 "1.1"],
+    ["0.002", "3.14159265",              "0.00000001"],
+    ["0.0",   "1.1",                     "-1235.1"],
+    ["-1.0",  "-1.0",                    "-2.0"],
+    ["0.002", "nan",                     "-nan"],
+    ["0.0",   "inf",                     "-inf"],
+    ["-1.0",  "quiet_nan",               "signaling_nan"],
+    ["0.002", "smallest_nonzero_float",  "largest_subnormal_float"],
+    ["0.0",   "smallest_normal_float",   "max_float"],
+    ["-1.0",  "-smallest_nonzero_float", "-largest_subnormal_float"],
+    ["0.002", "-smallest_normal_float",  "-max_float"]
+]
+

--- a/generator/insn.go
+++ b/generator/insn.go
@@ -16,11 +16,12 @@ import (
 type insnFormat string
 
 type Option struct {
-	VLEN    VLEN
-	XLEN    XLEN
-	Fp      bool
-	Repeat  int
-	Float16 bool
+	VLEN     VLEN
+	XLEN     XLEN
+	Fp       bool
+	Repeat   int
+	Float16  bool
+	Bfloat16 bool
 }
 
 const minStride = -1 // Must be negative
@@ -407,7 +408,15 @@ func (i *Insn) testCases(float bool, sew SEW) [][]any {
 		}
 	case 16:
 		if float {
-			for _, c := range i.Tests.FSEW16 {
+			var testCases []testCase[uint16]
+
+			if i.Option.Bfloat16 {
+				testCases = i.Tests.BF16SEW16
+			} else {
+				testCases = i.Tests.FSEW16
+			}
+
+			for _, c := range testCases {
 				l := make([]any, len(c))
 				for b, op := range c {
 					l[b] = op

--- a/generator/insn_g.go
+++ b/generator/insn_g.go
@@ -91,7 +91,14 @@ func (i *Insn) gWriteTestData(float bool, testfloat bool, cont bool, lmul LMUL, 
 			_ = binary.Write(buf, binary.LittleEndian, convNum[uint8](cases[b][idx]))
 		case 16:
 			if (float && testfloat && a >= len(cases)) || cont {
-				_ = binary.Write(buf, binary.LittleEndian, nextf16())
+				var val uint16
+				if i.Option.Bfloat16 {
+					// Perform simple truncation (round towards zero)
+					val = uint16(math.Float32bits(nextf32()) >> 16)
+				} else {
+					val = nextf16()
+				}
+				_ = binary.Write(buf, binary.LittleEndian, val)
 			} else {
 				b := a % len(cases)
 				_ = binary.Write(buf, binary.LittleEndian, convNum[uint16](cases[b][idx]))

--- a/generator/insn_vdfs1vs2vm.go
+++ b/generator/insn_vdfs1vs2vm.go
@@ -7,10 +7,13 @@ import (
 )
 
 func (i *Insn) genCodeVdFs1Vs2Vm(pos int) []string {
+	float := strings.HasPrefix(i.Name, "vf")
 	vdWidening := strings.HasPrefix(i.Name, "vfw")
+	sew16Only := strings.HasPrefix(i.Name, "vfwmaccbf16")
 	vdSize := iff(vdWidening, 2, 1)
 
 	sews := iff(vdWidening, i.floatSEWs()[:len(i.floatSEWs())-1], i.floatSEWs())
+	sews = iff(sew16Only, []SEW{16}, sews)
 	combinations := i.combinations(
 		iff(vdWidening, wideningMULs, allLMULs),
 		sews,
@@ -36,13 +39,13 @@ func (i *Insn) genCodeVdFs1Vs2Vm(pos int) []string {
 		vd, vs2, _ := getVRegs(vdEMUL1, false, i.Name)
 
 		for r := 0; r < i.Option.Repeat; r += 1 {
-			builder.WriteString(i.gWriteTestData(true, !i.NoTestfloat3, r != 0, vdEMUL1, vdEEW, 0, 2))
+			builder.WriteString(i.gWriteTestData(float, !i.NoTestfloat3, r != 0, vdEMUL1, vdEEW, 0, 2))
 			builder.WriteString(i.gLoadDataIntoRegisterGroup(vd, vdEMUL1, vdEEW))
 
-			builder.WriteString(i.gWriteTestData(true, !i.NoTestfloat3, r != 0, c.LMUL1, c.SEW, 1, 2))
+			builder.WriteString(i.gWriteTestData(float, !i.NoTestfloat3, r != 0, c.LMUL1, c.SEW, 1, 2))
 			builder.WriteString(i.gLoadDataIntoRegisterGroup(vs2, c.LMUL1, c.SEW))
 
-			cases := i.testCases(true, c.SEW)
+			cases := i.testCases(float, c.SEW)
 			for a := 0; a < len(cases); a++ {
 				builder.WriteString("# -------------- TEST BEGIN --------------\n")
 				switch c.SEW {

--- a/generator/insn_vdvs1vs2vm.go
+++ b/generator/insn_vdvs1vs2vm.go
@@ -9,11 +9,14 @@ import (
 func (i *Insn) genCodeVdVs1Vs2Vm(pos int) []string {
 	float := strings.HasPrefix(i.Name, "vf")
 	vdWidening := strings.HasPrefix(i.Name, "vw") || strings.HasPrefix(i.Name, "vfw")
+	sew16Only := strings.HasPrefix(i.Name, "vfwmaccbf16")
 	vdSize := iff(vdWidening, 2, 1)
 	vs1Size := 1
 
 	sews := iff(float, i.floatSEWs(), allSEWs)
 	sews = iff(vdWidening, sews[:len(sews)-1], sews)
+	sews = iff(sew16Only, []SEW{16}, sews)
+
 	combinations := i.combinations(
 		iff(vdWidening, wideningMULs, allLMULs),
 		sews,

--- a/generator/insn_vdvs2vm.go
+++ b/generator/insn_vdvs2vm.go
@@ -10,11 +10,14 @@ func (i *Insn) genCodeVdVs2Vm(pos int) []string {
 	float := strings.HasPrefix(i.Name, "vf")
 	vdWidening := strings.HasPrefix(i.Name, "vfw")
 	vdNarrowing := strings.HasPrefix(i.Name, "vfn")
+	sew16Only := strings.HasPrefix(i.Name, "vfwcvtbf16") || strings.HasPrefix(i.Name, "vfncvtbf16")
+
 	vdSize := iff(vdWidening, 2, 1)
 	vs2Size := iff(vdNarrowing, 2, 1)
 
 	lmuls := iff(vdWidening || vdNarrowing, wideningMULs, allLMULs)
 	sews := iff(vdWidening || vdNarrowing, i.floatSEWs()[:len(i.floatSEWs())-1], i.floatSEWs())
+	sews = iff(sew16Only, []SEW{16}, sews)
 	combinations := i.combinations(lmuls, sews, []bool{false, true}, i.rms())
 
 	res := make([]string, 0, len(combinations))

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 func parse_extension(march string) []string {
-	var valid_exts = []string{"zvbb", "zvbc", "zfh", "zvfh", "zvkg", "zvkned", "zvknha", "zvksed", "zvksh"}
+	var valid_exts = []string{"zvbb", "zvbc", "zfh", "zvfh", "zvkg", "zvkned", "zvknha", "zvksed", "zvksh", "zvfbfmin", "zvfbfwma"}
 	var exts = []string{}
 	exts = append(exts, "v") // standard RVV
 	for _, s := range valid_exts {
@@ -72,7 +72,7 @@ var stage1OutputDirF = flag.String("stage1output", "", "stage1 output directory.
 var configsDirF = flag.String("configs", "configs/", "config files directory.")
 var testfloat3LevelF = flag.Int("testfloat3level", 2, "testfloat3 testing level (1 or 2).")
 var repeatF = flag.Int("repeat", 1, "repeat same V instruction n times for a better coverage (only valid for float instructions).")
-var march = flag.String("march", "gcv_zvbb_zvbc_zfh_zvfh_zvkg_zvkned_zvknha_zvksed_zvksh", "march")
+var march = flag.String("march", "gcv_zvbb_zvbc_zfh_zvfh_zvkg_zvkned_zvknha_zvksed_zvksh_zvfbfmin_zvfbfwma", "march")
 
 func main() {
 	flag.Parse()
@@ -154,6 +154,10 @@ func main() {
 				option.Repeat = 1
 			} else {
 				option.Fp = true
+			}
+
+			if strings.Contains(file.Name(), "bf16") {
+				option.Bfloat16 = true
 			}
 
 			insn, err := generator.ReadInsnFromToml(contents, option)


### PR DESCRIPTION
Add basic support for Bfloat16 and enable testing of the Zvfbfmin and Zvfbfwma extensions, both of which operate on Bfloat16 values.

 - The random float32 number generator is reused to produce random Bfloat16 inputs.
 - All constants defined in `/generator/tests.go` are native Bfloat16 values.
 - All directly defined values (as part of the config file) and random inputs, are derived from float32 and converted by truncating the lower 16 bits, which corresponds to rounding toward zero.
   (This excludes explicitly defined constants such as nan, -nan, inf, -inf, and similar special values, which are native bfloat16 values.)