### PR TITLE
Revert "Remove max limit of VLEN (#81)"

### DIFF
--- a/generator/insn_util.go
+++ b/generator/insn_util.go
@@ -104,7 +104,7 @@ func (l LMUL) String() string {
 type VLEN int
 
 func (v VLEN) Valid() bool {
-	return 64 <= v && v&(v-1) == 0
+	return 64 <= v && v <= 4096 && v&(v-1) == 0
 }
 
 type XLEN int

--- a/generator/insn_util.go
+++ b/generator/insn_util.go
@@ -104,7 +104,7 @@ func (l LMUL) String() string {
 type VLEN int
 
 func (v VLEN) Valid() bool {
-	return 64 <= v && v <= 4096 && v&(v-1) == 0
+	return 64 <= v && v <= 65536 && v&(v-1) == 0
 }
 
 type XLEN int


### PR DESCRIPTION
This reverts commit 6fbf8e1.
In chapter 30.2, the ISA manual specify the implementation-defined
constant parameter constaint: The number of bits in a single vector
register, VLEN ≥ ELEN, which must be a power of 2, and must be no
greater than 2^16.

Fix #81.