### PR TITLE
Fix test generation for VLEN=64

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,40 +1,38 @@
 name: Build and Test
 
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request, workflow_dispatch]
 
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-
-  workflow_dispatch:
+env:
+  SPIKE_COMMIT: f51df5d3955a27602a872eaf01492177513baf6f
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        VLEN: [256, 128, 64]
+        XLEN: [64, 32]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - uses: actions/setup-go@v4
+        with:
+          go-version: '1.25.1'
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install device-tree-compiler
-
-      - name: Get Spike Cache Key
-        id: get-spike-cache-key
-        run: |
-          echo "key=5a1145742e701597eb45825855311dfad21232a6" >> $GITHUB_OUTPUT
+          sudo apt-get update
+          sudo apt-get install -y device-tree-compiler
 
       - name: Cache Spike
         id: cache-spike
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/riscv
-          key: ${{ runner.os }}-${{ steps.get-spike-cache-key.outputs.key }}-spike
+          key: ${{ runner.os }}-spike-${{ env.SPIKE_COMMIT }}
 
       - name: Install Toolchain
         if: steps.cache-spike.outputs.cache-hit != 'true'
@@ -46,7 +44,7 @@ jobs:
         run: |
           git clone https://github.com/riscv-software-src/riscv-isa-sim.git
           cd riscv-isa-sim
-          git reset --hard b0d7621ff8e9520aaacd57d97d4d99a545062d14
+          git reset --hard ${{ env.SPIKE_COMMIT }}
           mkdir build
           cd build
           ../configure --prefix=${{ github.workspace }}/riscv
@@ -57,9 +55,5 @@ jobs:
         run: |
           export PATH="${{ github.workspace }}/riscv/bin:$PATH"
           export RISCV="${{ github.workspace }}/riscv"
-          make generate-stage1 --environment-overrides VLEN=256
-          make all -j$(nproc) --environment-overrides VLEN=256
-          make generate-stage1 --environment-overrides VLEN=128
-          make all -j$(nproc) --environment-overrides VLEN=128
-          make generate-stage1 --environment-overrides VLEN=128 XLEN=32
-          make all -j$(nproc) --environment-overrides VLEN=128 XLEN=32
+          make generate-stage1 --environment-overrides VLEN=${{ matrix.VLEN }} XLEN=${{ matrix.XLEN }}
+          make all -j$(nproc) --environment-overrides VLEN=${{ matrix.VLEN }} XLEN=${{ matrix.XLEN }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository hosts unit tests generator for the RISC-V vector extension.
 - Support RV32 and RV64
 - Test SEW from e8 to e64
 - Test LMUL from mf8 to m8
-- Support VLEN from 64 to 4096
+- Support VLEN from 64 to 65536
 - Support varies sub-extensions: Zvfh, Zvbb, Zvbc, Zvkg, Zvkned, Zvknha, Zvksed, Zvksh, Zvfbfmin and Zvfbfwma
 - Configurable, see `make help`
 

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ var stage1OutputDirF = flag.String("stage1output", "", "stage1 output directory.
 var configsDirF = flag.String("configs", "configs/", "config files directory.")
 var testfloat3LevelF = flag.Int("testfloat3level", 2, "testfloat3 testing level (1 or 2).")
 var repeatF = flag.Int("repeat", 1, "repeat same V instruction n times for a better coverage (only valid for float instructions).")
-var march = flag.String("march", "gcv_zvbb_zvbc_zfh_zvfh_zvkg_zvkned_zvknha_zvksed_zvksh_zvfbfmin_zvfbfwma", "march")
+var march = flag.String("march", "gcv_zvbb_zvbc_zfh_zvfh_zvkg_zvkned_zvknha_zvksed_zvksh_zfbfmin_zvfbfmin_zvfbfwma", "march")
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
- Fixed test generation when VLEN=64. (Addresses issues reported in #78 and #64)
- Updated CI workflow to run matrix strategy for different VLEN and ELEN combinations and locally with tools like act as well as on forks.
- Bumped to a new Spike version. The old version had incorrect dependencies for the Zvfbfmin and Zvfbfwma extensions.