### PR TITLE
Update to latest Spike version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  SPIKE_COMMIT: f51df5d3955a27602a872eaf01492177513baf6f
+  SPIKE_COMMIT: 591cff16109ced6a21bb2a612a3853b4e9cbd86d
 
 jobs:
   check:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  SPIKE_COMMIT: 591cff16109ced6a21bb2a612a3853b4e9cbd86d
+  SPIKE_COMMIT: 509bec19b01aa2f0445045cad6c540698714efad
 
 jobs:
   check:

--- a/pspike/pspike.cc
+++ b/pspike/pspike.cc
@@ -83,6 +83,7 @@ int main(int argc, char** argv) {
   sim_t sim(&cfg, false,
             mems,
             plugin_device_factories,
+            false,
             htif_args,
             dm_config,
             nullptr,


### PR DESCRIPTION
Disable DTB discovery, which was introduced in https://github.com/riscv-software-src/riscv-isa-sim/commit/2c94ea431ed26f9830e576d3493cd431f4119b98