### PR TITLE
VLEN32 Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ ifeq ($(shell [ $(XLEN) -gt $(VLEN) ] && echo yes),yes)
 $(error ELEN=$(XLEN) cannot be greater than VLEN=$(VLEN))
 endif
 
-ifeq ($(VLEN), 64)
-# For VLEN=64, use embedded vector extensions instead of full 'v'
+ifneq ($(filter $(VLEN),32 64),)
+# For VLEN<=64, use embedded vector extensions instead of full 'v'
 EXT_V =
 else
 # For VLEN >= 128, use full vector extension

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository hosts unit tests generator for the RISC-V vector extension.
 - Support RV32 and RV64
 - Test SEW from e8 to e64
 - Test LMUL from mf8 to m8
-- Support VLEN from 64 to 65536
+- Support VLEN from 32 to 65536 (VLEN=32 requires XLEN=32)
 - Support varies sub-extensions: Zvfh, Zvbb, Zvbc, Zvkg, Zvkned, Zvknha, Zvksed, Zvksh, Zvfbfmin and Zvfbfwma
 - Configurable, see `make help`
 

--- a/generator/insn.go
+++ b/generator/insn.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -29,6 +28,7 @@ const strides = maxStride - minStride
 
 type TestData struct {
 	CurrentOffset uint64
+	VLEN          VLEN
 
 	Raws [][]byte
 }
@@ -42,13 +42,22 @@ func (t *TestData) Append(raw []byte) uint64 {
 
 func (t *TestData) String() string {
 	builder := strings.Builder{}
+	dir := ".quad"
+	size := 8
+	if t.VLEN == 32 {
+		dir = ".word"
+		size = 4
+	}
 	for _, raw := range t.Raws {
-		for len(raw) > 0 {
-			reader := bytes.NewReader(raw)
-			var data uint64
-			_ = binary.Read(reader, binary.LittleEndian, &data)
-			raw = raw[8:]
-			builder.WriteString(fmt.Sprintf("  .quad 0x%x\n", data))
+		for len(raw) >= size {
+			var val uint64
+			if size == 4 {
+				val = uint64(binary.LittleEndian.Uint32(raw[:4]))
+			} else {
+				val = binary.LittleEndian.Uint64(raw[:8])
+			}
+			fmt.Fprintf(&builder, "  %s 0x%x\n", dir, val)
+			raw = raw[size:]
 		}
 	}
 	return builder.String()
@@ -240,7 +249,7 @@ func ReadInsnFromToml(contents []byte, option Option) (*Insn, error) {
 	i := Insn{
 		Option:   option,
 		EGW:      0,
-		TestData: &TestData{},
+		TestData: &TestData{VLEN: option.VLEN},
 	}
 
 	if err := i.check(); err != nil {
@@ -334,7 +343,7 @@ RVTEST_CODE_END
 					codeRes = append(codeRes, buf)
 					dataRes = append(dataRes, i.genData())
 				}
-				i.TestData = &TestData{}
+				i.TestData = &TestData{VLEN: i.Option.VLEN}
 				builder.Reset()
 				pos += idx
 				if idx == len(cs)-1 {

--- a/generator/insn_util.go
+++ b/generator/insn_util.go
@@ -104,12 +104,15 @@ func (l LMUL) String() string {
 type VLEN int
 
 func (v VLEN) Valid() bool {
-	return 64 <= v && v <= 65536 && v&(v-1) == 0
+	return 32 <= v && v <= 65536 && v&(v-1) == 0
 }
 
 type XLEN int
 
 func (x XLEN) Valid(v VLEN) bool {
+	if x == 64 && v < 64 {
+		return false
+	}
 	return x == 32 || x == 64
 }
 

--- a/generator/insn_util_test.go
+++ b/generator/insn_util_test.go
@@ -4,6 +4,9 @@ import "testing"
 
 func TestVLEN_Valid(t *testing.T) {
 	tests := map[VLEN]bool{
+		16:     false,
+		32:     true,
+		64:     true,
 		128:    true,
 		129:    false,
 		256:    true,

--- a/merger/merger.go
+++ b/merger/merger.go
@@ -41,7 +41,7 @@ func main() {
 	files, err := os.ReadDir(*stage1OutputDirF)
 	fatalIf(err)
 
-	r := regexp.MustCompile(".word 0x.+")
+	r := regexp.MustCompile(`(?m)^\.word 0x[0-9a-f]+\n`)
 	for _, file := range files {
 		asmFilepath := filepath.Join(*stage1OutputDirF, file.Name())
 		patchFilepath := filepath.Join(*stage2PatchDirF,


### PR DESCRIPTION
The vector spec defines Zve32x with minimum VLEN of 32.

It would be good for this generator to support this configuration. 
The main change is just using `.word` rather than `.quad` for testdata.

Then a small adjustment to the patch code to not match .word within testdata.