### PR TITLE
Skip vmulh/vsmul SEW=64 tests on Zve64-only targets

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  SPIKE_COMMIT: f51df5d3955a27602a872eaf01492177513baf6f
+  SPIKE_COMMIT: 20feb9c2bf2a7deab964d8190b0cbd4b4131bec3
 
 jobs:
   check:
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.25.1'
+          go-version: "1.25.1"
 
       - name: Install Dependencies
         run: |

--- a/generator/insn.go
+++ b/generator/insn.go
@@ -17,6 +17,7 @@ type insnFormat string
 type Option struct {
 	VLEN     VLEN
 	XLEN     XLEN
+	HasV	 bool
 	Fp       bool
 	Repeat   int
 	Float16  bool

--- a/generator/insn_vdvs2rs1vm.go
+++ b/generator/insn_vdvs2rs1vm.go
@@ -12,9 +12,11 @@ func (i *Insn) genCodeVdVs2Rs1Vm(pos int) []string {
 	sew64Only := strings.HasPrefix(i.Name, "vclmul")
 	vdSize := iff(vdWidening, 2, 1)
 	vs2Size := iff(vs2Widening, 2, 1)
+	noSew64WithoutV := strings.HasPrefix(i.Name, "vmulh") || strings.HasPrefix(i.Name, "vsmul")
 
 	sews := iff(vdWidening || vs2Widening, allSEWs[:len(allSEWs)-1], allSEWs)
 	sews = iff(sew64Only, []SEW{64}, sews)
+	sews = iff(noSew64WithoutV && !i.Option.HasV, []SEW{8, 16, 32}, sews)
 	combinations := i.combinations(
 		iff(vdWidening || vs2Widening, wideningMULs, iff(sew64Only, []LMUL{1, 2, 4, 8}, allLMULs)),
 		sews,

--- a/generator/insn_vdvs2vs1vm.go
+++ b/generator/insn_vdvs2vs1vm.go
@@ -12,6 +12,7 @@ func (i *Insn) genCodeVdVs2Vs1Vm(pos int) []string {
 	vdWidening := strings.HasPrefix(i.Name, "vw") || strings.HasPrefix(i.Name, "vfw")
 	vs2Widening := strings.HasSuffix(i.Name, ".wv")
 	isWideningReduction := strings.HasPrefix(i.Name, "vwred") || strings.HasPrefix(i.Name, "vfwred")
+	noSew64WithoutV := strings.HasPrefix(i.Name, "vmulh") || strings.HasPrefix(i.Name, "vsmul")
 
 	vdSize := iff(vdWidening, 2, 1)
 	vs2Size := iff(vs2Widening, 2, 1)
@@ -19,6 +20,7 @@ func (i *Insn) genCodeVdVs2Vs1Vm(pos int) []string {
 	sews := iff(float, i.floatSEWs(), allSEWs)
 	sews = iff(vdWidening || vs2Widening, sews[:len(sews)-1], sews)
 	sews = iff(sew64Only, []SEW{64}, sews)
+	sews = iff(noSew64WithoutV && !i.Option.HasV, []SEW{8, 16, 32}, sews)
 
 	lmuls := iff((vdWidening || vs2Widening) && !isWideningReduction,
 		wideningMULs, iff(sew64Only, []LMUL{1, 2, 4, 8}, allLMULs))

--- a/main.go
+++ b/main.go
@@ -45,6 +45,13 @@ func parse_extension(march string) []string {
 	return exts
 }
 
+func hasVExtension(march string) bool {
+    base := strings.SplitN(march, "_", 2)[0]
+    base = strings.TrimPrefix(base, "rv32")
+    base = strings.TrimPrefix(base, "rv64")
+    return strings.Contains(base, "v")
+}
+
 type FileTuple struct {
 	Entry    os.DirEntry
 	FullPath string
@@ -161,6 +168,7 @@ func main() {
 			option := generator.Option{
 				VLEN:    generator.VLEN(*vlenF),
 				XLEN:    generator.XLEN(*xlenF),
+				HasV:    hasVExtension(*march),
 				Repeat:  *repeatF,
 				Float16: float16F,
 			}

--- a/pspike/pspike.cc
+++ b/pspike/pspike.cc
@@ -83,6 +83,7 @@ int main(int argc, char** argv) {
   sim_t sim(&cfg, false,
             mems,
             plugin_device_factories,
+            false,
             htif_args,
             dm_config,
             nullptr,


### PR DESCRIPTION
Per V spec, vmulh.{vv,vx}, vmulhu.{vv,vx}, vmulhsu.{vv,vx} and vsmul.{vv,vx} are not available at EEW=64 in Zve64*. Spike commit d1e34d0 enforces this, which broke the v64x64 build (no full V at VLEN=64).

Add an Option.HasV flag derived from the march string and skip SEW=64 generation for these eight instructions when V is absent.

Surfaced in #87 while bumping the Spike version.

Additionally update Spike to latest commit.